### PR TITLE
Add env to lightning ignore

### DIFF
--- a/.lightningignore
+++ b/.lightningignore
@@ -3,3 +3,12 @@
 .storage
 train_df
 test_df
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Adding python env to .lightningignore to avoid uploading the env to the app source code
cc: @Nachimak28 